### PR TITLE
Make ERC20Locker ERC223 compatible

### DIFF
--- a/erc20-connector/contracts/ERC20Locker.sol
+++ b/erc20-connector/contracts/ERC20Locker.sol
@@ -58,6 +58,12 @@ contract ERC20Locker is Locker {
         result.recipient = address(uint160(recipient));
     }
 
+    // tokenFallback implements the ContractReceiver interface from ERC223-token-standard.
+    // This allows to support ERC223 tokens with no extra cost.
+    // The function always passes: we don't need to make any decision and the contract always
+    // accept token transfers transfer.
+    function tokenFallback(address _from, uint _value, bytes _data) public pure {}
+
     address public admin_;
 
     modifier onlyAdmin {


### PR DESCRIPTION
There are few ERC223 tokens out there and we would like to support them on the NEAR side. 
However, ERC223 has this rigorous check:  it doesn't allow token transfers to contracts that don't support token receiving and handling.
This PR implements a dummy `tokenFallback` function to satisfy ERC223 requirements.