### PR TITLE
refactor: run 'cargo fmt' in all Rust directories

### DIFF
--- a/bridge-token-factory/src/prover.rs
+++ b/bridge-token-factory/src/prover.rs
@@ -2,20 +2,19 @@ use std::convert::From;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use eth_types::*;
-use ethabi::{Event, EventParam, Hash, ParamType, RawLog, Token, Log};
 use ethabi::param_type::Writer;
+use ethabi::{Event, EventParam, Hash, Log, ParamType, RawLog, Token};
 //use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{ext_contract};
+use near_sdk::ext_contract;
 
 use tiny_keccak::Keccak;
 
 pub type EthAddress = [u8; 20];
 
 pub fn validate_eth_address(address: String) -> EthAddress {
-    let data =
-        hex::decode(address).expect("address should be a valid hex string.");
+    let data = hex::decode(address).expect("address should be a valid hex string.");
     assert_eq!(data.len(), 20, "address should be 20 bytes long");
-    let mut result  = [0u8; 20];
+    let mut result = [0u8; 20];
     result.copy_from_slice(&data);
     result
 }
@@ -54,7 +53,18 @@ pub struct EthEvent {
 
 impl EthEvent {
     pub fn from_log_entry_data(name: &str, params: EthEventParams, data: &[u8]) -> Self {
-        let event = Event { name: name.to_string(), inputs: params.into_iter().map(|(name, kind, indexed)| EventParam { name, kind, indexed }).collect(), anonymous: false };
+        let event = Event {
+            name: name.to_string(),
+            inputs: params
+                .into_iter()
+                .map(|(name, kind, indexed)| EventParam {
+                    name,
+                    kind,
+                    indexed,
+                })
+                .collect(),
+            anonymous: false,
+        };
         let log_entry: LogEntry = rlp::decode(data).expect("Invalid RLP");
         let locker_address = (log_entry.address.clone().0).0;
         let raw_log = RawLog {
@@ -68,18 +78,34 @@ impl EthEvent {
         let log = event.parse_log(raw_log).expect("Failed to parse event log");
         Self {
             locker_address,
-            log
+            log,
         }
     }
 
-    pub fn to_log_entry_data(name: &str, params: EthEventParams, locker_address: EthAddress, indexes: Vec<Vec<u8>>, values: Vec<Token>) -> Vec<u8> {
-        let event = Event { name: name.to_string(), inputs: params.into_iter().map(|(name, kind, indexed)| EventParam { name: name.to_string(), kind, indexed }).collect(), anonymous: false };
+    pub fn to_log_entry_data(
+        name: &str,
+        params: EthEventParams,
+        locker_address: EthAddress,
+        indexes: Vec<Vec<u8>>,
+        values: Vec<Token>,
+    ) -> Vec<u8> {
+        let event = Event {
+            name: name.to_string(),
+            inputs: params
+                .into_iter()
+                .map(|(name, kind, indexed)| EventParam {
+                    name: name.to_string(),
+                    kind,
+                    indexed,
+                })
+                .collect(),
+            anonymous: false,
+        };
         let params: Vec<ParamType> = event.inputs.iter().map(|p| p.kind.clone()).collect();
         let topics = indexes.into_iter().map(|value| H256::from(value)).collect();
         let log_entry = LogEntry {
             address: locker_address.into(),
-            topics: vec![vec![
-                long_signature(&event.name, &params).0.into()], topics].concat(),
+            topics: vec![vec![long_signature(&event.name, &params).0.into()], topics].concat(),
             data: ethabi::encode(&values),
         };
         rlp::encode(&log_entry)
@@ -93,7 +119,11 @@ fn long_signature(name: &str, params: &[ParamType]) -> Hash {
 }
 
 fn fill_signature(name: &str, params: &[ParamType], result: &mut [u8]) {
-    let types = params.iter().map(Writer::write).collect::<Vec<String>>().join(",");
+    let types = params
+        .iter()
+        .map(Writer::write)
+        .collect::<Vec<String>>()
+        .join(",");
 
     let data: Vec<u8> = From::from(format!("{}({})", name, types).as_str());
 

--- a/bridge-token-factory/tests/token_transfer.rs
+++ b/bridge-token-factory/tests/token_transfer.rs
@@ -26,11 +26,17 @@ pub struct BridgeToken {
 
 impl BridgeToken {
     pub fn get_balance(&self, runtime: &mut TestRuntime, owner: String) -> String {
-        TokenContract { contract_id: self.contract_id.clone() }.get_balance(runtime, owner)
+        TokenContract {
+            contract_id: self.contract_id.clone(),
+        }
+        .get_balance(runtime, owner)
     }
 
     pub fn get_total_supply(&self, runtime: &mut TestRuntime) -> String {
-        TokenContract { contract_id: self.contract_id.clone() }.get_total_supply(runtime)
+        TokenContract {
+            contract_id: self.contract_id.clone(),
+        }
+        .get_total_supply(runtime)
     }
 
     pub fn mint(
@@ -270,7 +276,10 @@ fn test_near_token_transfer() {
         token.get_balance(&mut runtime, root.clone()),
         to_yocto("900").to_string()
     );
-    assert_eq!(token.get_total_supply(&mut runtime), to_yocto("1000").to_string());
+    assert_eq!(
+        token.get_total_supply(&mut runtime),
+        to_yocto("1000").to_string()
+    );
 
     let mut proof = Proof::default();
     proof.log_entry_data = EthUnlockedEvent {
@@ -286,7 +295,10 @@ fn test_near_token_transfer() {
         token.get_balance(&mut runtime, ALICE.to_string()),
         to_yocto("50").to_string()
     );
-    assert_eq!(token.get_total_supply(&mut runtime), to_yocto("1000").to_string());
+    assert_eq!(
+        token.get_total_supply(&mut runtime),
+        to_yocto("1000").to_string()
+    );
 }
 
 #[test]

--- a/bridge-token/src/lib.rs
+++ b/bridge-token/src/lib.rs
@@ -1,6 +1,6 @@
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::U128;
-use near_sdk::{env, near_bindgen, AccountId, Promise, Balance, ext_contract};
+use near_sdk::{env, ext_contract, near_bindgen, AccountId, Balance, Promise};
 
 use near_lib::token::{FungibleToken, Token};
 
@@ -53,8 +53,15 @@ impl BridgeToken {
     }
 
     pub fn withdraw(&mut self, amount: U128, recipient: String) -> Promise {
-        self.token.burn(env::predecessor_account_id(), amount.into());
-        ext_bridge_token_factory::finish_withdraw(amount.into(), recipient, &self.controller, NO_DEPOSIT, env::prepaid_gas() / 2)
+        self.token
+            .burn(env::predecessor_account_id(), amount.into());
+        ext_bridge_token_factory::finish_withdraw(
+            amount.into(),
+            recipient,
+            &self.controller,
+            NO_DEPOSIT,
+            env::prepaid_gas() / 2,
+        )
     }
 }
 

--- a/mock-prover/src/lib.rs
+++ b/mock-prover/src/lib.rs
@@ -8,7 +8,9 @@ pub struct MockProver {}
 #[near_bindgen]
 impl MockProver {
     #[init]
-    pub fn new() -> Self { MockProver {} }
+    pub fn new() -> Self {
+        MockProver {}
+    }
 
     #[result_serializer(borsh)]
     pub fn verify_log_entry(


### PR DESCRIPTION
[rustfmt] can be added to most editors, and can also be run using `cargo fmt` within a specific Rust project

  [rustfmt]: https://doc.rust-lang.org/book/appendix-04-useful-development-tools.html